### PR TITLE
Add Locust load testing setup with JWT authentication

### DIFF
--- a/core/locust/locustfile.py
+++ b/core/locust/locustfile.py
@@ -1,0 +1,17 @@
+from locust import HttpUser, task
+
+
+class MyUser(HttpUser):
+    def on_start(self):
+
+        response = self.client.post(
+            "/accounts/api/v1/jwt/create/",
+            data={"username": "erf1", "password": "hasaniii1234"},
+        ).json()
+        self.client.headers = {
+            "Authorization": f"Bearer {response.get('access', None)}"
+        }
+
+    @task
+    def todo_list(self):
+        self.client.get("/api/v1/todo/")

--- a/core/todo/api/v1/urls.py
+++ b/core/todo/api/v1/urls.py
@@ -1,4 +1,4 @@
-from todo.api.v1.views import TaskModelSerializer
+from todo.api.v1.views import TaskViewSet
 from rest_framework.routers import DefaultRouter
 
 
@@ -6,6 +6,6 @@ app_name = "api-v1"
 
 router = DefaultRouter()
 
-router.register("todo", TaskModelSerializer, basename="todo")
+router.register("todo", TaskViewSet, basename="todo")
 
 urlpatterns = router.urls

--- a/core/todo/api/v1/views.py
+++ b/core/todo/api/v1/views.py
@@ -1,12 +1,12 @@
 from rest_framework import viewsets
 from .serializers import TaskSerializer
 from ...models import Task
-from rest_framework.permissions import IsAuthenticatedOrReadOnly
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.filters import OrderingFilter
 
 
-class TaskModelSerializer(viewsets.ModelViewSet):
-    permission_classes = [IsAuthenticatedOrReadOnly]
+class TaskViewSet(viewsets.ModelViewSet):
+    permission_classes = [IsAuthenticated]
     serializer_class = TaskSerializer
     queryset = Task.objects.all()
     filter_backends = [OrderingFilter]

--- a/core/todo/tests/test_todo_list.py
+++ b/core/todo/tests/test_todo_list.py
@@ -6,6 +6,7 @@ import pytest
 class TestTodoList:
 
     def test_get_list(self, api_client, test_user, task_factory):
+        api_client.force_authenticate(user=test_user)
         """Tests if the API correctly retrieves the list of tasks."""
         task_factory(user=test_user, title="Task 1", complete=False)
         task_factory(user=test_user, title="Task 2", complete=True)
@@ -14,6 +15,7 @@ class TestTodoList:
         assert response.status_code == 200
 
     def test_get_task_detail(self, api_client, test_user, task_factory):
+        api_client.force_authenticate(user=test_user)
         """Tests if the API correctly retrieves a single task's details."""
         task = task_factory(
             user=test_user, title="Task Detail", complete=False

--- a/core/todo/urls.py
+++ b/core/todo/urls.py
@@ -11,7 +11,7 @@ from todo.views import (
 app_name = "taskApp"
 urlpatterns = [
     path("", TaskListView.as_view(), name="task-view"),
-    path("todo/api", TaskListApiView.as_view(), name="task-api-view"),
+    path("todo/api/", TaskListApiView.as_view(), name="task-api-view"),
     path("create", TaskCreateView.as_view(), name="task-create"),
     path("edit/<int:pk>", EditTask.as_view(), name="task-edit"),
     path("complete/<int:pk>", CompleteTask.as_view(), name="task-complete"),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
-
-
+        
 services:
   backend:
     build: .
@@ -7,6 +6,7 @@ services:
     command: python manage.py runserver 0.0.0.0:8000
     volumes:
       - ./core:/app
+      - /app/__pycache__/
     ports:
       - "8000:8000"
     environment:
@@ -16,7 +16,7 @@ services:
     image: rnwood/smtp4dev:v3
     restart: always
     ports:
-      # Change the number before:to the port the web interface should be accessible on
+      # Change the number before : to the port the web interface should be accessible on
       - '5000:80'
       # Change the number before : to the port the SMTP server should be accessible on
       - '25:25'
@@ -31,5 +31,21 @@ services:
 
       #Specifies the server hostname. Used in auto-generated TLS certificate if enabled.
       - ServerOptions__HostName=smtp4dev
+  master:
+    image: locustio/locust
+    ports:
+     - "8089:8089"
+    volumes:
+      - ./core/locust:/mnt/locust
+    command: -f /mnt/locust/locustfile.py --master -H http://backend:8000
+  
+  worker:
+    image: locustio/locust
+    volumes:
+      - ./core/locust:/mnt/locust
+    command: -f /mnt/locust/locustfile.py --worker --master-host master
 volumes:
   smtp4dev-data:
+
+      
+       

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,4 +45,4 @@ Faker
 
 #--
 django-cors-headers
-
+locust


### PR DESCRIPTION
- Configured Locust master and worker setup in Docker Compose to perform load testing.
- Implemented JWT authentication in the Locust script to authenticate requests.
- Added the task to fetch the todo list via the API.
- The Locust master is configured to point to the backend server running on port 8000.