### PR TITLE
Update database settings to use PostgreSQL and add environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,12 @@ ENV PYTHONUNBUFFERED=1
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y libpq-dev
+RUN apt-get update && apt-get install -y --no-install-recommends libpq-dev
+
+RUN apt-get install -y postgresql-client
 
 COPY requirements.txt /app/
-
 RUN pip3 install --upgrade pip
 RUN pip3 install -r requirements.txt
 
-RUN pip3 install psycopg2-binary
-
-COPY ./core /app
+COPY . /app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,13 @@ ENV PYTHONUNBUFFERED=1
 
 WORKDIR /app
 
+RUN apt-get update && apt-get install -y libpq-dev
+
 COPY requirements.txt /app/
 
 RUN pip3 install --upgrade pip
 RUN pip3 install -r requirements.txt
+
+RUN pip3 install psycopg2-binary
 
 COPY ./core /app

--- a/core/core/settings.py
+++ b/core/core/settings.py
@@ -95,13 +95,14 @@ WSGI_APPLICATION = "core.wsgi.application"
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
-        'NAME': os.getenv('POSTGRES_DB', 'todo_django_db'),
-        'USER': os.getenv('POSTGRES_USER', 'erfan'),
-        'PASSWORD': os.getenv('POSTGRES_PASSWORD', 'ZxCv@#1234567'),
-        'HOST': os.getenv('POSTGRES_HOST', 'db'),
-        'PORT': '5432',
+        'NAME': os.getenv('DB_NAME', 'todo_django_db'),
+        'USER': os.getenv('DB_USER', 'erfan'),
+        'PASSWORD': os.getenv('DB_PASSWORD', 'ZxCv@#1234567'),
+        'HOST': os.getenv('DB_HOST', 'db'),
+        'PORT': os.getenv('DB_PORT', '5432'),
     }
 }
+
 
 
 

--- a/core/core/settings.py
+++ b/core/core/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/5.1/ref/settings/
 
 from pathlib import Path
 from decouple import config
+import os
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -91,13 +92,17 @@ WSGI_APPLICATION = "core.wsgi.application"
 
 # Database
 # https://docs.djangoproject.com/en/5.1/ref/settings/#databases
-
 DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': os.getenv('POSTGRES_DB', 'todo_django_db'),
+        'USER': os.getenv('POSTGRES_USER', 'erfan'),
+        'PASSWORD': os.getenv('POSTGRES_PASSWORD', 'ZxCv@#1234567'),
+        'HOST': os.getenv('POSTGRES_HOST', 'db'),
+        'PORT': '5432',
     }
 }
+
 
 
 # Password validation

--- a/docker-compose-stage.yml
+++ b/docker-compose-stage.yml
@@ -22,10 +22,28 @@ services:
     environment:
       - SECRET_KEY=test
       - DEBUG=False
+      - DB_NAME=todo_django_db
+      - DB_USER=erfan
+      - DB_PASSWORD=ZxCv@#1234567
+      - DB_HOST=db
+      - DB_PORT=5432
     expose:
       - "8000"
     depends_on:
       - redis
+      - db
+  db:
+    image: postgres
+    container_name: postgres
+    restart: always
+    volumes:
+      - postgres_data:/var/lib/postgresql/data/
+    environment:
+      - POSTGRES_USER=erfan
+      - POSTGRES_PASSWORD=ZxCv@#1234567
+      - POSTGRES_DB=todo_django_db
+
+
   nginx:
     image: nginx
     container_name: nginx-todo
@@ -75,6 +93,7 @@ services:
 volumes:
   static_volume:
   media_volume:
+  postgres_data:
 
 
       

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,3 +38,7 @@ requests
 
 # Deployment
 gunicorn
+
+# Database
+psycopg2-binary
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,3 +42,4 @@ gunicorn
 # Database
 psycopg2-binary
 
+


### PR DESCRIPTION
- Replaced SQLite database configuration with PostgreSQL settings in Django project.
- Added PostgreSQL environment variables for database connection (DB_NAME, DB_USER, DB_PASSWORD, DB_HOST, DB_PORT).
- Installed psycopg2-binary and libpq-dev for PostgreSQL support.
- Configured Docker container for PostgreSQL and set environment variables.
- Updated `DATABASES` settings in Django to use PostgreSQL.